### PR TITLE
use token symbol if payment token != ETH or WETH

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,11 +10,17 @@ function formatAndSendTweet(event) {
     const openseaLink = _.get(event, ['asset', 'permalink']);
     const totalPrice = _.get(event, 'total_price');
     const usdValue = _.get(event, ['payment_token', 'usd_price']);
+    const tokenSymbol = _.get(event, ['payment_token', 'symbol']);
 
-    const formattedEthPrice = ethers.utils.formatEther(totalPrice.toString());
-    const formattedUsdPrice = (formattedEthPrice * usdValue).toFixed(2);
+    const formattedTokenPrice = ethers.utils.formatEther(totalPrice.toString());
+    const formattedUsdPrice = (formattedTokenPrice * usdValue).toFixed(2);
+    const formattedPriceSymbol = (
+        (tokenSymbol === 'WETH' || tokenSymbol === 'ETH') 
+            ? 'Ξ' 
+            : ` ${tokenSymbol}`
+    );
 
-    const tweetText = `${tokenName} bought for ${formattedEthPrice}Ξ ($${formattedUsdPrice}) #NFTs ${openseaLink}`;
+    const tweetText = `${tokenName} bought for ${formattedTokenPrice}${formattedPriceSymbol} ($${formattedUsdPrice}) #NFTs ${openseaLink}`;
 
     console.log(tweetText);
 


### PR DESCRIPTION
- fixes problem where purchases in tokens other than ETH still display as ETH (see https://twitter.com/frwcbot/status/1417481898473951240 where purchase was for 250 DAI but displays as ETH)
- use Ξ when WETH or ETH, otherwise use a space plus the token symbol (e.g. DAI, USDC)
- still uses `ethers.utils.formatEther()` for calculating token price but it's good enuf & I don't think it makes a big difference in precision